### PR TITLE
Update base.py, if the given parameter 'variables' is a string, convert it to a dictionary

### DIFF
--- a/llama_hub/tools/graphql/base.py
+++ b/llama_hub/tools/graphql/base.py
@@ -15,13 +15,13 @@ class GraphQLToolSpec(BaseToolSpec):
         self.headers = headers
         self.url = url
 
-    def graphql_request(self, query: str, variables: str, operation_name: str):
+    def graphql_request(self, query: str, variables: dict, operation_name: str):
         """
         Use this tool to make a GraphQL query against the server.
 
         Args:
             query (str): The GraphQL query to execute
-            variables (str): The variable values for the query
+            variables (dict): The variable values for the query
             operation_name (str): The name for the query
 
         example input:
@@ -30,6 +30,11 @@ class GraphQLToolSpec(BaseToolSpec):
             "operation_name":"Ships"
 
         """
+
+        # if the given parameter 'variables' is a string, convert to dict
+        if isinstance(variables, str):
+            variables = eval(variables)
+            
         res = requests.post(
             self.url,
             headers=self.headers,


### PR DESCRIPTION
# Description

The parameter 'variables' should be a dictionary rather than a string. The current implementation triggers errors when the value of 'variables' is a string like "{\\"id\\": \\"walmart\\"}". In this case, an example error from the GraphQL server ariadne is like below:

ERROR:ariadne:Query variables must be a null or an object.

Fixes # (issue)


## Type of Change
- [x] Bug fix / Smaller change

# How Has This Been Tested?
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `make format; make lint` to appease the lint gods